### PR TITLE
CNV-81685 fix: handle missing builds gracefully instead of crashing

### DIFF
--- a/src/cnv_upgrade_utilities/release_checklist_upgrade_plan.py
+++ b/src/cnv_upgrade_utilities/release_checklist_upgrade_plan.py
@@ -187,12 +187,15 @@ def get_upgrade_paths_info(
     help="Skip target channel validation. Use when the target build hasn't reached stable stage yet.",
 )
 def main(target_version: str, skip_target_check: bool):
-    with CnvVersionExplorer() as explorer:
-        version_info = get_upgrade_paths_info(
-            explorer=explorer, target_version=Version(target_version), skip_target_check=skip_target_check
-        )
+    try:
+        with CnvVersionExplorer() as explorer:
+            version_info = get_upgrade_paths_info(
+                explorer=explorer, target_version=Version(target_version), skip_target_check=skip_target_check
+            )
 
-        click.echo(json.dumps(version_info, indent=2, default=str))
+            click.echo(json.dumps(version_info, indent=2, default=str))
+    except ValueError as exc:
+        raise SystemExit(f"Error: {exc}")
 
 
 if __name__ == "__main__":

--- a/src/cnv_upgrade_utilities/release_checklist_upgrade_plan.py
+++ b/src/cnv_upgrade_utilities/release_checklist_upgrade_plan.py
@@ -194,7 +194,7 @@ def main(target_version: str, skip_target_check: bool):
             )
 
             click.echo(json.dumps(version_info, indent=2, default=str))
-    except ValueError as exc:
+    except (ValueError, ConnectionError, TimeoutError) as exc:
         raise SystemExit(f"Error: {exc}")
 
 

--- a/src/cnv_upgrade_utilities/upgrade_jobs_info.py
+++ b/src/cnv_upgrade_utilities/upgrade_jobs_info.py
@@ -378,7 +378,7 @@ def main(source_version: str, target_version: str):
         with CnvVersionExplorer() as explorer:
             result = get_upgrade_jobs_info(explorer=explorer, source_version=source_version, target_version=target_version)
             click.echo(json.dumps(result, indent=2))
-    except ValueError as exc:
+    except (ValueError, ConnectionError, TimeoutError) as exc:
         raise SystemExit(f"Error: {exc}")
 
 

--- a/src/cnv_upgrade_utilities/upgrade_jobs_info.py
+++ b/src/cnv_upgrade_utilities/upgrade_jobs_info.py
@@ -374,9 +374,12 @@ def get_upgrade_jobs_info(explorer: CnvVersionExplorer, source_version: str, tar
     help="Target version: 4.Y, 4.Y.Z, or 4.Y.Z.rhelR-BN (e.g., 4.20, 4.20.5, 4.20.5.rhel9-3)",
 )
 def main(source_version: str, target_version: str):
-    with CnvVersionExplorer() as explorer:
-        result = get_upgrade_jobs_info(explorer=explorer, source_version=source_version, target_version=target_version)
-        click.echo(json.dumps(result, indent=2))
+    try:
+        with CnvVersionExplorer() as explorer:
+            result = get_upgrade_jobs_info(explorer=explorer, source_version=source_version, target_version=target_version)
+            click.echo(json.dumps(result, indent=2))
+    except ValueError as exc:
+        raise SystemExit(f"Error: {exc}")
 
 
 if __name__ == "__main__":

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -15,3 +15,8 @@ CHANNEL_CANDIDATE = "candidate"
 # Environment Variable Names
 # ============================================================================
 ENV_VERSION_EXPLORER_URL = "VERSION_EXPLORER_URL"
+
+# ============================================================================
+# Default API URLs
+# ============================================================================
+DEFAULT_VERSION_EXPLORER_URL = "http://cnv-version-explorer.apps.cnv2.engineering.redhat.com/"

--- a/src/utils/version_explorer.py
+++ b/src/utils/version_explorer.py
@@ -8,7 +8,7 @@ import requests
 from requests.exceptions import ConnectionError, HTTPError, Timeout, TooManyRedirects
 from timeout_sampler import TimeoutSampler
 
-from utils.constants import CHANNEL_STABLE, ENV_VERSION_EXPLORER_URL
+from utils.constants import CHANNEL_STABLE, DEFAULT_VERSION_EXPLORER_URL, ENV_VERSION_EXPLORER_URL
 
 LOGGER = logging.getLogger(__name__)
 
@@ -58,9 +58,7 @@ class CnvVersionExplorer:
         Raises:
             ValueError: If URL is not provided and VERSION_EXPLORER_URL is not set
         """
-        self._url = url or os.environ.get(ENV_VERSION_EXPLORER_URL)
-        if not self._url:
-            raise ValueError("URL must be provided or VERSION_EXPLORER_URL environment variable must be set")
+        self._url = url or os.environ.get(ENV_VERSION_EXPLORER_URL) or DEFAULT_VERSION_EXPLORER_URL
         self.request_timeout = request_timeout
         self.retry_timeout = retry_timeout
         self._session: requests.Session | None = None

--- a/src/utils/version_explorer.py
+++ b/src/utils/version_explorer.py
@@ -224,13 +224,18 @@ class CnvVersionExplorer:
         Returns:
             Dictionary with build info including cnv_version, current_channel,
             and channels array
+
+        Raises:
+            ValueError: If the build is not found in Version Explorer
         """
-        # Prepend 'v' if not present (API expects v4.20.3.rhel9-31)
         version_param = bundle_version if bundle_version.startswith("v") else f"v{bundle_version}"
-        return self.query_with_retry(
+        result = self.query_with_retry(
             endpoint="GetBuildInfo",
             query_string=f"version={version_param}",
         )
+        if "error" in result:
+            raise ValueError(f"Build not found: {bundle_version}. Check if the build exists in CNV Version Explorer.")
+        return result
 
 
 # --- Helper functions (stateless, no API dependency) ---

--- a/tests/test_e2e.sh
+++ b/tests/test_e2e.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# E2E tests for CNV-81685: graceful error handling of missing/invalid builds.
+# Requires: VERSION_EXPLORER_URL in .env, network access to Version Explorer.
+#
+# Usage: bash tests/test_e2e.sh
+#
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR=$(cd "$(dirname "$0")/.."; pwd)
+
+run_test() {
+    local name="$1"
+    local expect_exit="$2"   # 0 = success, 1 = clean error
+    local expect_match="$3"  # string that must appear in output
+    local reject_match="${4:-Traceback}"  # string that must NOT appear
+    shift 4
+    local cmd=("$@")
+
+    local display_cmd="${cmd[*]}"
+    echo "  RUN   ${display_cmd}"
+
+    output=$("${cmd[@]}" 2>&1)
+    actual_exit=$?
+
+    local ok=true
+
+    if [[ "$expect_exit" != "$actual_exit" ]]; then
+        ok=false
+    fi
+
+    if [[ -n "$expect_match" ]] && ! echo "$output" | grep -qF "$expect_match"; then
+        ok=false
+    fi
+
+    if [[ -n "$reject_match" ]] && echo "$output" | grep -qF "$reject_match"; then
+        ok=false
+    fi
+
+    if $ok; then
+        echo "  PASS  $name"
+    else
+        echo "  FAIL  $name"
+        echo "        expected exit=$expect_exit got=$actual_exit"
+        echo "        expected match='$expect_match'"
+        echo "        reject  match='$reject_match'"
+        echo "        output (first 3 lines):"
+        echo "$output" | head -3 | sed 's/^/        /'
+    fi
+
+    if $ok; then ((PASS++)); else ((FAIL++)); fi
+    echo ""
+}
+
+echo "=== E2E tests for error handling (CNV-81685) ==="
+echo "    Working dir: ${SCRIPT_DIR}"
+echo ""
+
+cd "$SCRIPT_DIR"
+
+# --- upgrade_jobs_info ---
+
+echo "-- upgrade_jobs_info --"
+
+run_test "non-existent target version" \
+    1 "Error:" "Traceback" \
+    uv run upgrade_jobs_info -s 4.16.0 -t 4.16.99
+
+run_test "non-existent target build (4.16.31)" \
+    1 "Error:" "Traceback" \
+    uv run upgrade_jobs_info -s 4.16.0 -t 4.16.31
+
+run_test "downgrade rejected" \
+    1 "Error:" "Traceback" \
+    uv run upgrade_jobs_info -s 4.16.999 -t 4.16.36
+
+run_test "cross-minor rejected without Y-stream flag" \
+    1 "Error:" "Traceback" \
+    uv run upgrade_jobs_info -s 4.18.0 -t 4.19.5
+
+run_test "valid Z-stream upgrade returns JSON" \
+    0 '"upgrade_type"' "Traceback" \
+    uv run upgrade_jobs_info -s 4.16.0 -t 4.16.36
+
+echo ""
+
+# --- release_checklist_upgrade_plan ---
+
+echo "-- release_checklist_upgrade_plan --"
+
+run_test "non-existent version (4.16.99)" \
+    1 "Error:" "Traceback" \
+    uv run release_checklist_upgrade_plan -v 4.16.99
+
+run_test "non-existent minor (4.99.1)" \
+    1 "Error:" "Traceback" \
+    uv run release_checklist_upgrade_plan -v 4.99.1
+
+run_test "already released version without flag" \
+    1 "Error:" "Traceback" \
+    uv run release_checklist_upgrade_plan -v 4.16.36
+
+run_test "already released with --skip-target-check returns JSON" \
+    0 '"target_version"' "Traceback" \
+    uv run release_checklist_upgrade_plan -v 4.16.36 --skip-target-check
+
+run_test "old version 4.12.23 with --skip-target-check" \
+    0 '"target_version"' "Traceback" \
+    uv run release_checklist_upgrade_plan -v 4.12.23 --skip-target-check
+
+echo ""
+
+# --- Summary ---
+
+TOTAL=$((PASS + FAIL))
+echo "=== Results: ${PASS}/${TOTAL} passed ==="
+
+if [[ $FAIL -gt 0 ]]; then
+    echo "FAILED"
+    exit 1
+fi
+
+echo "ALL PASSED"


### PR DESCRIPTION
Replace IndexError/KeyError crashes with clear error messages when builds are not found in Version Explorer API.