### PR TITLE
fix(models): coerce ReleasedBuild.skips from string to list

### DIFF
--- a/src/utils/models.py
+++ b/src/utils/models.py
@@ -1,6 +1,8 @@
 """Pydantic models for Version Explorer API responses and internal data."""
 
-from pydantic import BaseModel, Field
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
 
 
 class ChannelInfo(BaseModel):
@@ -26,6 +28,18 @@ class ReleasedBuild(BaseModel):
     build_timestamp: str | None = None
 
     model_config = {"populate_by_name": True}
+
+    @field_validator("skips", mode="before")
+    @classmethod
+    def _coerce_skips(cls, v: Any) -> list[str]:
+        """API sometimes returns "" or null instead of [] for empty skips."""
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [s for s in v.split(",") if s] if v else []
+        if isinstance(v, list):
+            return v
+        return list(v)
 
 
 class SuccessfulBuild(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,25 @@
+from utils.models import ReleasedBuild
+
+
+class TestReleasedBuildSkipsCoercion:
+    """API sometimes returns skips as "" instead of []."""
+
+    def test_empty_string_coerced_to_empty_list(self):
+        build = ReleasedBuild(csv_version="v4.16.36", version="v4.16.36.rhel9-1", skips="")
+        assert build.skips == []
+
+    def test_none_uses_default_empty_list(self):
+        build = ReleasedBuild(csv_version="v4.16.36", version="v4.16.36.rhel9-1", skips=None)
+        assert build.skips == []
+
+    def test_comma_separated_string_coerced_to_list(self):
+        build = ReleasedBuild(csv_version="v4.16.36", version="v4.16.36.rhel9-1", skips="v4.16.34,v4.16.35")
+        assert build.skips == ["v4.16.34", "v4.16.35"]
+
+    def test_list_input_unchanged(self):
+        build = ReleasedBuild(csv_version="v4.16.36", version="v4.16.36.rhel9-1", skips=["v4.16.34"])
+        assert build.skips == ["v4.16.34"]
+
+    def test_missing_field_uses_default(self):
+        build = ReleasedBuild(csv_version="v4.16.36", version="v4.16.36.rhel9-1")
+        assert build.skips == []


### PR DESCRIPTION
Version Explorer API sometimes returns skips as "" or null instead of []. Add a Pydantic field_validator to coerce these to an empty list, and handle comma-separated strings (e.g. "v4.16.34,v4.16.35") as a list of individual versions.

Fixes: release_checklist_upgrade_plan -v 4.16.36 --skip-target-check crashing with "Input should be a valid list" ValidationError.