### PR TITLE
Add API caching, test logging, snapshot generation, and daily CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,18 @@
+name: Daily
+
+on:
+  schedule:
+    - cron: "17 6 * * *"   # Daily at 06:17 UTC
+  workflow_dispatch:        # Manual trigger
+
+jobs:
+  fbc:
+    name: "\U0001F4E6 FBC Verification"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv sync --extra dev
+      - run: uv run tox -e fbc

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ wheels/
 .coverage.*
 htmlcov/
 
+# Snapshots
+snapshots/
+
 # Claude Code
 CLAUDE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ packages = ["src/cnv_upgrade_utilities", "src/utils"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
-addopts = "-v --tb=short -m 'not e2e and not fbc'"
+addopts = "-v --tb=short"
 markers = [
     "e2e: end-to-end tests requiring VERSION_EXPLORER_URL",
     "fbc: FBC ground truth verification requiring cnv-fbc repo access",

--- a/scripts/generate_upgrade_snapshots.py
+++ b/scripts/generate_upgrade_snapshots.py
@@ -1,0 +1,171 @@
+"""Generate upgrade path and release checklist snapshots for all supported versions."""
+
+import argparse
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from packaging.version import Version
+
+from cnv_upgrade_utilities.release_checklist_upgrade_plan import get_upgrade_paths_info
+from cnv_upgrade_utilities.upgrade_jobs_info import get_upgrade_jobs_info
+from cnv_upgrade_utilities.upgrade_types import SUPPORTED_VERSIONS
+from cnv_upgrade_utilities.version_types import format_minor_version
+from utils.version_explorer import CnvVersionExplorer
+
+LOGGER = logging.getLogger("generate_snapshots")
+
+
+def probe_z_depths(explorer: CnvVersionExplorer) -> dict[str, int]:
+    """Probe Version Explorer to find max z per supported version."""
+    depths: dict[str, int] = {}
+    total = len(SUPPORTED_VERSIONS)
+
+    for i, version in enumerate(SUPPORTED_VERSIONS, 1):
+        minor_version = format_minor_version(version)
+        try:
+            builds = explorer.get_released_builds(minor_version=minor_version, stage=True)
+        except Exception:
+            LOGGER.warning("[%d/%d] %s: probe failed", i, total, version)
+            depths[version] = -1
+            continue
+
+        max_z = -1
+        for build in builds:
+            csv = build.csv_version.lstrip("v")
+            parts = csv.split(".")
+            if len(parts) >= 3:
+                max_z = max(max_z, int(parts[2]))
+        depths[version] = max_z
+        LOGGER.info("[%d/%d] %s: max_z=%d", i, total, version, max_z)
+
+    return depths
+
+
+def generate_upgrade_paths(explorer: CnvVersionExplorer, z_depths: dict[str, int]) -> tuple[list[dict], list[dict]]:
+    """Generate upgrade_jobs_info results for all valid upgrade path combinations."""
+    results: list[dict] = []
+    errors: list[dict] = []
+
+    paths_to_test: list[tuple[str, str, str]] = []
+    for version in SUPPORTED_VERSIONS:
+        max_z = z_depths.get(version, -1)
+        if max_z < 0:
+            continue
+
+        if max_z >= 1:
+            paths_to_test.append((version, version, "z_stream"))
+        if max_z >= 2:
+            paths_to_test.append((f"{version}.0", version, "latest_z"))
+
+        v = Version(version)
+        source_y = f"{v.major}.{v.minor - 1}"
+        if source_y in SUPPORTED_VERSIONS:
+            paths_to_test.append((source_y, version, "y_stream"))
+
+        if v.minor % 2 == 0:
+            source_eus = f"{v.major}.{v.minor - 2}"
+            if source_eus in SUPPORTED_VERSIONS:
+                paths_to_test.append((source_eus, version, "eus"))
+
+    total = len(paths_to_test)
+    LOGGER.info("Testing %d upgrade paths...", total)
+
+    for i, (source, target, expected_type) in enumerate(paths_to_test, 1):
+        label = f"{source} -> {target} ({expected_type})"
+        LOGGER.info("[%d/%d] %s", i, total, label)
+        try:
+            result = get_upgrade_jobs_info(explorer, source_version=source, target_version=target)
+            results.append({"path": label, **result})
+        except Exception as exc:
+            LOGGER.warning("[%d/%d] %s: %s", i, total, label, exc)
+            errors.append({"context": f"upgrade_jobs_info {label}", "error": str(exc)})
+
+    return results, errors
+
+
+def generate_release_checklists(
+    explorer: CnvVersionExplorer, z_depths: dict[str, int]
+) -> tuple[dict[str, dict], list[dict]]:
+    """Generate release checklist results for all supported versions."""
+    checklists: dict[str, dict] = {}
+    errors: list[dict] = []
+
+    versions_to_check = [(v, z) for v, z in z_depths.items() if z >= 0]
+    total = len(versions_to_check)
+    LOGGER.info("Generating release checklists for %d versions...", total)
+
+    for i, (version, max_z) in enumerate(versions_to_check, 1):
+        target = Version(f"{version}.{max_z}")
+        label = str(target)
+        LOGGER.info("[%d/%d] release_checklist: %s", i, total, label)
+        try:
+            result = get_upgrade_paths_info(explorer, target_version=target, skip_target_check=True)
+            checklists[label] = result
+        except Exception as exc:
+            LOGGER.warning("[%d/%d] release_checklist %s: %s", i, total, label, exc)
+            errors.append({"context": f"release_checklist {label}", "error": str(exc)})
+
+    return checklists, errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate upgrade path and release checklist snapshots")
+    parser.add_argument(
+        "--output-dir", type=Path, default=Path("snapshots"), help="Output directory (default: snapshots/)"
+    )
+    parser.add_argument("--stdout", action="store_true", help="Write to stdout instead of file")
+    parser.add_argument(
+        "--versions", type=str, default=None, help="Comma-separated subset of versions to process (default: all)"
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s", datefmt="%H:%M:%S")
+
+    if args.versions:
+        requested = [v.strip() for v in args.versions.split(",")]
+        invalid = [v for v in requested if v not in SUPPORTED_VERSIONS]
+        if invalid:
+            parser.error(f"Unknown versions: {', '.join(invalid)}. Valid: {', '.join(SUPPORTED_VERSIONS)}")
+
+    LOGGER.info("Starting snapshot generation for %d supported versions", len(SUPPORTED_VERSIONS))
+
+    with CnvVersionExplorer() as explorer:
+        z_depths = probe_z_depths(explorer)
+
+        if args.versions:
+            z_depths = {v: z for v, z in z_depths.items() if v in requested}
+
+        upgrade_results, upgrade_errors = generate_upgrade_paths(explorer, z_depths)
+        checklists, checklist_errors = generate_release_checklists(explorer, z_depths)
+
+    snapshot = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "supported_versions": SUPPORTED_VERSIONS,
+        "z_depths": z_depths,
+        "upgrade_paths": upgrade_results,
+        "release_checklists": checklists,
+        "errors": upgrade_errors + checklist_errors,
+    }
+
+    output = json.dumps(snapshot, indent=2, default=str)
+
+    if args.stdout:
+        sys.stdout.write(output + "\n")
+    else:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        output_path = args.output_dir / f"{date_str}.json"
+        output_path.write_text(output + "\n")
+        LOGGER.info("Snapshot written to %s", output_path)
+
+    error_count = len(snapshot["errors"])
+    if error_count:
+        LOGGER.warning("%d errors during generation", error_count)
+    LOGGER.info("Done: %d upgrade paths, %d checklists", len(upgrade_results), len(checklists))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/version_explorer.py
+++ b/src/utils/version_explorer.py
@@ -39,6 +39,7 @@ class CnvVersionExplorer:
         self.request_timeout = request_timeout
         self.retry_timeout = retry_timeout
         self._session: requests.Session | None = None
+        self._cache: dict[tuple[str, str], Any] = {}
 
     @property
     def url(self) -> str:
@@ -55,6 +56,7 @@ class CnvVersionExplorer:
         if self._session is not None:
             self._session.close()
             self._session = None
+        self._cache.clear()
 
     def __enter__(self) -> "CnvVersionExplorer":
         return self
@@ -79,7 +81,12 @@ class CnvVersionExplorer:
             return None
 
     def query_with_retry(self, endpoint: str, query_string: str) -> Any:
-        """Execute an API query with retry logic."""
+        """Execute an API query with retry logic. Results are cached per instance."""
+        cache_key = (endpoint, query_string)
+        if cache_key in self._cache:
+            LOGGER.debug("Cache hit: %s?%s", endpoint, query_string)
+            return self._cache[cache_key]
+
         sampler = TimeoutSampler(
             wait_timeout=self.retry_timeout,
             sleep=self.request_timeout,
@@ -91,6 +98,7 @@ class CnvVersionExplorer:
         )
         for sample in sampler:
             if sample:
+                self._cache[cache_key] = sample
                 return sample
 
     def get_released_builds(self, minor_version: str, stage: bool = False) -> list[ReleasedBuild]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,16 @@ import pytest
 from utils.models import BuildInfo, ChannelInfo, ReleasedBuild, SuccessfulBuild
 from utils.version_explorer import CnvVersionExplorer
 
+_EXTERNAL_MARKERS = {"e2e", "fbc"}
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-deselect e2e/fbc tests unless explicitly requested via -m."""
+    marker_expr = config.getoption("-m", default="")
+    if any(m in marker_expr for m in _EXTERNAL_MARKERS):
+        return
+    items[:] = [item for item in items if not (_EXTERNAL_MARKERS & {m.name for m in item.iter_markers()})]
+
 
 @pytest.fixture
 def mock_explorer():

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from packaging.version import Version
 
@@ -6,6 +8,8 @@ from cnv_upgrade_utilities.version_types import format_minor_version
 from utils.version_explorer import CnvVersionExplorer
 
 from .utils.expected_lanes import compute_expected_lanes
+
+LOGGER = logging.getLogger("cnv_e2e")
 
 _SUPPORTED_SET = frozenset(SUPPORTED_VERSIONS)
 
@@ -19,14 +23,17 @@ def _probe_version_z_depth() -> dict[str, int]:
         return _version_z_depth_cache
 
     depth = {}
+    total = len(SUPPORTED_VERSIONS)
+    LOGGER.info("Probing Version Explorer for z-depth of %d supported versions...", total)
     try:
         with CnvVersionExplorer(request_timeout=5, retry_timeout=10) as explorer:
-            for version in SUPPORTED_VERSIONS:
+            for i, version in enumerate(SUPPORTED_VERSIONS, 1):
                 minor_version = format_minor_version(version)
                 try:
                     builds = explorer.get_released_builds(minor_version=minor_version, stage=True)
                 except Exception:
                     depth[version] = -1
+                    LOGGER.info("[%d/%d] %s: probe failed", i, total, version)
                     continue
                 max_z = -1
                 for build in builds:
@@ -35,10 +42,13 @@ def _probe_version_z_depth() -> dict[str, int]:
                     if len(parts) >= 3:
                         max_z = max(max_z, int(parts[2]))
                 depth[version] = max_z
+                LOGGER.info("[%d/%d] %s: max_z=%d", i, total, version, max_z)
     except Exception:
+        LOGGER.warning("Version Explorer unreachable, marking all versions as unavailable")
         for version in SUPPORTED_VERSIONS:
             depth.setdefault(version, -1)
 
+    LOGGER.info("Z-depth probe complete: %d versions probed", len(depth))
     _version_z_depth_cache = depth
     return depth
 
@@ -75,6 +85,7 @@ def _generate_minor_paths(version_z_depth: dict[str, int]) -> list[tuple[str, st
             eus_source = f"{target.major}.{target.minor - 2}"
             paths.append((eus_source, version, "eus"))
 
+    LOGGER.info("Generated %d upgrade paths from API data", len(paths))
     return paths
 
 
@@ -131,7 +142,11 @@ def negative_paths() -> list[tuple[str, str]]:
         ("4.17", "4.19"),
         ("4.20.5", "4.20.5"),
     ]
-    return static + _generate_eol_negative_paths()
+    eol_paths = _generate_eol_negative_paths()
+    LOGGER.info(
+        "Generated %d negative paths (%d static + %d EOL)", len(static) + len(eol_paths), len(static), len(eol_paths)
+    )
+    return static + eol_paths
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_upgrade_paths.py
+++ b/tests/e2e/test_upgrade_paths.py
@@ -1,9 +1,13 @@
 """Structural E2E tests for upgrade path resolution against live Version Explorer API."""
 
+import logging
+
 import pytest
 
 from cnv_upgrade_utilities.upgrade_jobs_info import get_upgrade_jobs_info
 from cnv_upgrade_utilities.version_types import parse_minor_version, parse_patch_version
+
+LOGGER = logging.getLogger("cnv_e2e")
 
 
 def assert_upgrade_result_valid(result: dict, source_version: str, target_version: str, expected_type: str) -> None:
@@ -53,7 +57,9 @@ class TestMinorFormatPaths:
     """Upgrade paths using MINOR version format (4.Y)."""
 
     def test_minor_format(self, explorer, minor_paths):
-        for source_version, target_version, upgrade_type in minor_paths:
+        total = len(minor_paths)
+        for i, (source_version, target_version, upgrade_type) in enumerate(minor_paths, 1):
+            LOGGER.info("[%d/%d] minor_format: %s -> %s (%s)", i, total, source_version, target_version, upgrade_type)
             result = get_upgrade_jobs_info(explorer, source_version=source_version, target_version=target_version)
             assert_upgrade_result_valid(result, source_version, target_version, upgrade_type)
 
@@ -72,7 +78,9 @@ class TestFullFormatPaths:
     """
 
     def test_full_format(self, explorer, same_minor_paths):
-        for source_version, target_version, upgrade_type in same_minor_paths:
+        total = len(same_minor_paths)
+        for i, (source_version, target_version, upgrade_type) in enumerate(same_minor_paths, 1):
+            LOGGER.info("[%d/%d] full_format: %s -> %s (%s)", i, total, source_version, target_version, upgrade_type)
             minor_result = get_upgrade_jobs_info(explorer, source_version=source_version, target_version=target_version)
             source_full = minor_result["source"]["version"]
             target_full = minor_result["target"]["version"]
@@ -98,7 +106,9 @@ class TestBundleFormatPaths:
     """
 
     def test_bundle_format(self, explorer, same_minor_paths):
-        for source_version, target_version, upgrade_type in same_minor_paths:
+        total = len(same_minor_paths)
+        for i, (source_version, target_version, upgrade_type) in enumerate(same_minor_paths, 1):
+            LOGGER.info("[%d/%d] bundle_format: %s -> %s (%s)", i, total, source_version, target_version, upgrade_type)
             minor_result = get_upgrade_jobs_info(explorer, source_version=source_version, target_version=target_version)
             source_bundle = minor_result["source"]["bundle_version"]
             target_bundle = minor_result["target"]["bundle_version"]
@@ -117,14 +127,18 @@ class TestMixedFormatPaths:
     """Upgrade paths with source and target in different version formats."""
 
     def test_minor_source_full_target(self, explorer, same_minor_paths):
-        for source_version, target_version, upgrade_type in same_minor_paths:
+        total = len(same_minor_paths)
+        for i, (source_version, target_version, upgrade_type) in enumerate(same_minor_paths, 1):
+            LOGGER.info("[%d/%d] minor->full: %s -> %s (%s)", i, total, source_version, target_version, upgrade_type)
             minor_result = get_upgrade_jobs_info(explorer, source_version=source_version, target_version=target_version)
             target_full = minor_result["target"]["version"]
             result = get_upgrade_jobs_info(explorer, source_version=source_version, target_version=target_full)
             assert_upgrade_result_valid(result, source_version, target_full, upgrade_type)
 
     def test_full_source_bundle_target(self, explorer, same_minor_paths):
-        for source_version, target_version, upgrade_type in same_minor_paths:
+        total = len(same_minor_paths)
+        for i, (source_version, target_version, upgrade_type) in enumerate(same_minor_paths, 1):
+            LOGGER.info("[%d/%d] full->bundle: %s -> %s (%s)", i, total, source_version, target_version, upgrade_type)
             minor_result = get_upgrade_jobs_info(explorer, source_version=source_version, target_version=target_version)
             source_full = minor_result["source"]["version"]
             target_bundle = minor_result["target"]["bundle_version"]
@@ -146,7 +160,9 @@ class TestSupportedVersionCoverage:
     """Verify every SUPPORTED_VERSIONS entry with released builds works for Z-stream."""
 
     def test_z_stream_works(self, explorer, versions_with_z1):
-        for version in versions_with_z1:
+        total = len(versions_with_z1)
+        for i, version in enumerate(versions_with_z1, 1):
+            LOGGER.info("[%d/%d] z_stream_coverage: %s", i, total, version)
             result = get_upgrade_jobs_info(explorer, source_version=version, target_version=version)
             assert result["upgrade_type"] == "z_stream"
 
@@ -161,7 +177,9 @@ class TestNegativeUpgradePaths:
     """Validate that invalid upgrade paths raise appropriate errors."""
 
     def test_invalid_path_raises(self, explorer, negative_paths):
-        for source_version, target_version in negative_paths:
+        total = len(negative_paths)
+        for i, (source_version, target_version) in enumerate(negative_paths, 1):
+            LOGGER.info("[%d/%d] negative: %s -> %s", i, total, source_version, target_version)
             with pytest.raises((ValueError, TimeoutError)):
                 get_upgrade_jobs_info(explorer, source_version=source_version, target_version=target_version)
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,7 @@ commands =
 [testenv:py{312,314}]
 description = Run unit tests with coverage
 commands =
-    pytest --cov=cnv_upgrade_utilities --cov=utils --cov-append \
-        -m "not e2e and not fbc" {posargs}
+    pytest --cov=cnv_upgrade_utilities --cov=utils --cov-append {posargs}
 
 [testenv:security]
 description = Security scans
@@ -31,13 +30,19 @@ commands =
 [testenv:fbc]
 description = FBC ground truth verification (requires public internet for GitHub clone)
 commands =
-    pytest tests/e2e/ -m "fbc and not e2e" -v -o "addopts=" {posargs}
+    pytest tests/e2e/ -m "fbc and not e2e" --log-cli-level=INFO {posargs}
 
 [testenv:e2e]
 description = End-to-end tests against Version Explorer API (requires RH network)
 passenv = VERSION_EXPLORER_URL
 commands =
-    pytest tests/e2e/ -m e2e -v -o "addopts=" {posargs}
+    pytest tests/e2e/ -m e2e --log-cli-level=INFO {posargs}
+
+[testenv:generate]
+description = Generate upgrade path and release checklist snapshots (requires RH network)
+passenv = VERSION_EXPLORER_URL
+commands =
+    python scripts/generate_upgrade_snapshots.py {posargs}
 
 [testenv:coverage]
 description = Report coverage and enforce threshold


### PR DESCRIPTION
- Add instance-level response cache to CnvVersionExplorer to eliminate duplicate API calls within the same session
- Add progress logging to E2E test fixtures and loop-based tests with [N/M] counters for tracking test progress
- Move e2e/fbc marker exclusion from pyproject.toml addopts to a conftest hook that auto-deselects unless -m is passed explicitly
- Add snapshot generation script (scripts/generate_upgrade_snapshots.py) that produces daily JSON dumps of all upgrade paths and checklists
- Add tox generate environment for local snapshot generation
- Add daily GitHub Actions workflow for FBC verification
- Add --log-cli-level=INFO to tox e2e and fbc environments