### PR TITLE
Update 4.23 and 5.0: fix e2e test, docs, and testing paths

### DIFF
--- a/current_testing_paths/release-checklist.json
+++ b/current_testing_paths/release-checklist.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-08 06:08 UTC",
+  "generated_at": "2026-07-13 09:34 UTC",
   "supported_versions": [
     "4.12",
     "4.14",
@@ -15,21 +15,21 @@
   ],
   "versions": {
     "4.12": {
-      "target_version": "4.12.25",
+      "target_version": "4.12.26",
       "target_build_info": {
-        "version": "4.12.25",
-        "bundle_version": "4.12.25-39",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174851",
+        "version": "4.12.26",
+        "bundle_version": "4.12.26-4",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1177962",
         "channel": "candidate",
         "in_stage": true,
         "released_to_prod": false
       },
       "upgrade_lanes": {
         "Z stream": {
-          "source_version": "4.12.24",
-          "bundle_version": "4.12.24-22",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149500",
-          "channel": "stable",
+          "source_version": "4.12.25",
+          "bundle_version": "4.12.25-39",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174851",
+          "channel": "candidate",
           "post_upgrade_suite": "NONE"
         },
         "latest z": {
@@ -60,10 +60,10 @@
           "post_upgrade_suite": "NONE"
         },
         "EUS": {
-          "source_version": "4.12.24",
-          "bundle_version": "4.12.24-22",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149500",
-          "channel": "stable",
+          "source_version": "4.12.25",
+          "bundle_version": "4.12.25-39",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174851",
+          "channel": "candidate",
           "post_upgrade_suite": "UTS-Marker"
         },
         "latest z": {
@@ -185,11 +185,11 @@
       }
     },
     "4.19": {
-      "target_version": "4.19.28",
+      "target_version": "4.19.29",
       "target_build_info": {
-        "version": "4.19.28",
-        "bundle_version": "4.19.28.rhel9-14",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1165370",
+        "version": "4.19.29",
+        "bundle_version": "4.19.29.rhel9-31",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1176679",
         "channel": "stable",
         "in_stage": true,
         "released_to_prod": false
@@ -203,9 +203,9 @@
           "post_upgrade_suite": "UTS-Marker"
         },
         "Z stream": {
-          "source_version": "4.19.27",
-          "bundle_version": "4.19.27.rhel9-6",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1158970",
+          "source_version": "4.19.28",
+          "bundle_version": "4.19.28.rhel9-14",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1164900",
           "channel": "candidate",
           "post_upgrade_suite": "NONE"
         },
@@ -230,9 +230,9 @@
       },
       "upgrade_lanes": {
         "Y stream": {
-          "source_version": "4.19.28",
-          "bundle_version": "4.19.28.rhel9-14",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1164900",
+          "source_version": "4.19.29",
+          "bundle_version": "4.19.29.rhel9-31",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1175611",
           "channel": "candidate",
           "post_upgrade_suite": "UTS-Marker"
         },
@@ -338,14 +338,34 @@
       "target_version": "4.23.0",
       "target_build_info": {
         "version": "4.23.0",
-        "bundle_version": "4.23.0.rhel9-8",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1175410",
+        "bundle_version": "4.23.0.rhel9-16",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178065",
         "channel": "candidate",
         "in_stage": true,
         "released_to_prod": false
       },
       "upgrade_lanes": {
         "Y stream": {
+          "source_version": "4.22.2",
+          "bundle_version": "4.22.2.rhel9-12",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1170067",
+          "channel": "candidate",
+          "post_upgrade_suite": "UTS-FULL"
+        }
+      }
+    },
+    "5.0": {
+      "target_version": "5.0.0",
+      "target_build_info": {
+        "version": "5.0.0",
+        "bundle_version": "5.0.0.rhel9-14",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178068",
+        "channel": "candidate",
+        "in_stage": true,
+        "released_to_prod": false
+      },
+      "upgrade_lanes": {
+        "Y stream (4.22)": {
           "source_version": "4.22.2",
           "bundle_version": "4.22.2.rhel9-12",
           "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1170067",

--- a/current_testing_paths/release-checklist.md
+++ b/current_testing_paths/release-checklist.md
@@ -1,14 +1,14 @@
 # Release Checklist
 
-Generated: 2026-07-08 06:08 UTC | Versions: 10
+Generated: 2026-07-13 09:34 UTC | Versions: 11
 
-## 4.12 -> 4.12.25
+## 4.12 -> 4.12.26
 
-**Target**: 4.12.25 (4.12.25-39) | channel: candidate | **in stage** | not released to prod
+**Target**: 4.12.26 (4.12.26-4) | channel: candidate | **in stage** | not released to prod
 
 | Lane | Source | IIB | Channel | Post-Upgrade Suite |
 |------|--------|-----|---------|-------------------|
-| Z stream | 4.12.24 | iib:1149500 | stable | NONE |
+| Z stream | 4.12.25 | iib:1174851 | candidate | NONE |
 | latest z | 4.12.0 | iib:399135 | stable | NONE |
 
 ## 4.14 -> 4.14.24
@@ -18,7 +18,7 @@ Generated: 2026-07-08 06:08 UTC | Versions: 10
 | Lane | Source | IIB | Channel | Post-Upgrade Suite |
 |------|--------|-----|---------|-------------------|
 | Z stream | 4.14.23 | iib:1168279 | candidate | NONE |
-| EUS | 4.12.24 | iib:1149500 | stable | UTS-Marker |
+| EUS | 4.12.25 | iib:1174851 | candidate | UTS-Marker |
 | latest z | 4.14.0 | iib:611376 | stable | NONE |
 
 ## 4.16 -> 4.16.40
@@ -52,14 +52,14 @@ Generated: 2026-07-08 06:08 UTC | Versions: 10
 | EUS | 4.16.40 | iib:1172274 | candidate | NONE |
 | latest z | 4.18.0 | iib:928381 | stable | NONE |
 
-## 4.19 -> 4.19.28
+## 4.19 -> 4.19.29
 
-**Target**: 4.19.28 (4.19.28.rhel9-14) | channel: stable | **in stage** | not released to prod
+**Target**: 4.19.29 (4.19.29.rhel9-31) | channel: stable | **in stage** | not released to prod
 
 | Lane | Source | IIB | Channel | Post-Upgrade Suite |
 |------|--------|-----|---------|-------------------|
 | Y stream | 4.18.41 | iib:1174052 | candidate | UTS-Marker |
-| Z stream | 4.19.27 | iib:1158970 | candidate | NONE |
+| Z stream | 4.19.28 | iib:1164900 | candidate | NONE |
 | latest z | 4.19.0 | iib:991381 | stable | NONE |
 
 ## 4.20 -> 4.20.20
@@ -68,7 +68,7 @@ Generated: 2026-07-08 06:08 UTC | Versions: 10
 
 | Lane | Source | IIB | Channel | Post-Upgrade Suite |
 |------|--------|-----|---------|-------------------|
-| Y stream | 4.19.28 | iib:1164900 | candidate | UTS-Marker |
+| Y stream | 4.19.29 | iib:1175611 | candidate | UTS-Marker |
 | Z stream | 4.20.19 | iib:1165585 | candidate | NONE |
 | EUS | 4.18.41 | iib:1174052 | candidate | NONE |
 | latest z | 4.20.0 | iib:1063267 | stable | NONE |
@@ -96,8 +96,16 @@ Generated: 2026-07-08 06:08 UTC | Versions: 10
 
 ## 4.23 -> 4.23.0
 
-**Target**: 4.23.0 (4.23.0.rhel9-8) | channel: candidate | **in stage** | not released to prod
+**Target**: 4.23.0 (4.23.0.rhel9-16) | channel: candidate | **in stage** | not released to prod
 
 | Lane | Source | IIB | Channel | Post-Upgrade Suite |
 |------|--------|-----|---------|-------------------|
 | Y stream | 4.22.2 | iib:1170067 | candidate | UTS-FULL |
+
+## 5.0 -> 5.0.0
+
+**Target**: 5.0.0 (5.0.0.rhel9-14) | channel: candidate | **in stage** | not released to prod
+
+| Lane | Source | IIB | Channel | Post-Upgrade Suite |
+|------|--------|-----|---------|-------------------|
+| Y stream (4.22) | 4.22.2 | iib:1170067 | candidate | UTS-FULL |

--- a/current_testing_paths/upgrade-paths.json
+++ b/current_testing_paths/upgrade-paths.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-08 06:08 UTC",
+  "generated_at": "2026-07-13 09:34 UTC",
   "supported_versions": [
     "4.12",
     "4.14",
@@ -14,35 +14,35 @@
     "5.0"
   ],
   "latest_z": {
-    "4.12": 25,
-    "4.14": 24,
+    "4.12": 26,
+    "4.14": 25,
     "4.16": 41,
     "4.17": 54,
     "4.18": 42,
-    "4.19": 29,
+    "4.19": 30,
     "4.20": 21,
     "4.21": 13,
     "4.22": 3,
     "4.23": 0,
-    "5.0": -1
+    "5.0": 0
   },
   "versions": {
     "4.12": {
-      "latest_z": 25,
+      "latest_z": 26,
       "upgrade_paths": {
         "z_stream": {
           "source": {
-            "version": "4.12.24",
-            "bundle_version": "4.12.24-22",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149500",
-            "channel": "stable",
+            "version": "4.12.25",
+            "bundle_version": "4.12.25-39",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174851",
+            "channel": "candidate",
             "in_stage": false,
             "released_to_prod": true
           },
           "target": {
-            "version": "4.12.25",
-            "bundle_version": "4.12.25-39",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174851",
+            "version": "4.12.26",
+            "bundle_version": "4.12.26-4",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1177962",
             "channel": "candidate",
             "in_stage": true,
             "released_to_prod": false
@@ -58,9 +58,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.12.25",
-            "bundle_version": "4.12.25-39",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174851",
+            "version": "4.12.26",
+            "bundle_version": "4.12.26-4",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1177962",
             "channel": "candidate",
             "in_stage": true,
             "released_to_prod": false
@@ -69,7 +69,7 @@
       }
     },
     "4.14": {
-      "latest_z": 24,
+      "latest_z": 25,
       "upgrade_paths": {
         "z_stream": {
           "source": {
@@ -109,10 +109,10 @@
         },
         "eus": {
           "source": {
-            "version": "4.12.24",
-            "bundle_version": "4.12.24-22",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149500",
-            "channel": "stable",
+            "version": "4.12.25",
+            "bundle_version": "4.12.25-39",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174851",
+            "channel": "candidate",
             "in_stage": false,
             "released_to_prod": true
           },
@@ -323,21 +323,21 @@
       }
     },
     "4.19": {
-      "latest_z": 29,
+      "latest_z": 30,
       "upgrade_paths": {
         "z_stream": {
           "source": {
-            "version": "4.19.27",
-            "bundle_version": "4.19.27.rhel9-6",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1158970",
+            "version": "4.19.28",
+            "bundle_version": "4.19.28.rhel9-14",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1164900",
             "channel": "candidate",
             "in_stage": false,
             "released_to_prod": true
           },
           "target": {
-            "version": "4.19.28",
-            "bundle_version": "4.19.28.rhel9-14",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1165370",
+            "version": "4.19.29",
+            "bundle_version": "4.19.29.rhel9-31",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1176679",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -353,9 +353,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.19.28",
-            "bundle_version": "4.19.28.rhel9-14",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1165370",
+            "version": "4.19.29",
+            "bundle_version": "4.19.29.rhel9-31",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1176679",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -371,9 +371,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.19.28",
-            "bundle_version": "4.19.28.rhel9-14",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1165370",
+            "version": "4.19.29",
+            "bundle_version": "4.19.29.rhel9-31",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1176679",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -422,11 +422,11 @@
         },
         "y_stream": {
           "source": {
-            "version": "4.19.28",
-            "bundle_version": "4.19.28.rhel9-14",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1164900",
+            "version": "4.19.29",
+            "bundle_version": "4.19.29.rhel9-31",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1175611",
             "channel": "candidate",
-            "in_stage": false,
+            "in_stage": true,
             "released_to_prod": true
           },
           "target": {
@@ -608,8 +608,31 @@
           },
           "target": {
             "version": "4.23.0",
-            "bundle_version": "4.23.0.rhel9-8",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1175410",
+            "bundle_version": "4.23.0.rhel9-16",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178065",
+            "channel": "candidate",
+            "in_stage": true,
+            "released_to_prod": false
+          }
+        }
+      }
+    },
+    "5.0": {
+      "latest_z": 0,
+      "upgrade_paths": {
+        "y_stream": {
+          "source": {
+            "version": "4.22.2",
+            "bundle_version": "4.22.2.rhel9-12",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1170067",
+            "channel": "candidate",
+            "in_stage": true,
+            "released_to_prod": true
+          },
+          "target": {
+            "version": "5.0.0",
+            "bundle_version": "5.0.0.rhel9-14",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178068",
             "channel": "candidate",
             "in_stage": true,
             "released_to_prod": false

--- a/current_testing_paths/upgrade-paths.md
+++ b/current_testing_paths/upgrade-paths.md
@@ -1,21 +1,21 @@
 # Upgrade Paths
 
-Generated: 2026-07-08 06:08 UTC | Versions: 10 | Paths: 30
+Generated: 2026-07-13 09:34 UTC | Versions: 11 | Paths: 31
 
-## 4.12 (latest z: 25)
+## 4.12 (latest z: 26)
 
 | Type | Source | Target | Channel |
 |------|--------|--------|---------|
-| z_stream | 4.12.24 | 4.12.25 | candidate |
-| latest_z | 4.12.0 | 4.12.25 | candidate |
+| z_stream | 4.12.25 | 4.12.26 | candidate |
+| latest_z | 4.12.0 | 4.12.26 | candidate |
 
-## 4.14 (latest z: 24)
+## 4.14 (latest z: 25)
 
 | Type | Source | Target | Channel |
 |------|--------|--------|---------|
 | z_stream | 4.14.23 | 4.14.24 | stable |
 | latest_z | 4.14.0 | 4.14.24 | stable |
-| eus | 4.12.24 | 4.14.24 | stable |
+| eus | 4.12.25 | 4.14.24 | stable |
 
 ## 4.16 (latest z: 41)
 
@@ -42,13 +42,13 @@ Generated: 2026-07-08 06:08 UTC | Versions: 10 | Paths: 30
 | y_stream | 4.17.53 | 4.18.41 | stable |
 | eus | 4.16.40 | 4.18.41 | stable |
 
-## 4.19 (latest z: 29)
+## 4.19 (latest z: 30)
 
 | Type | Source | Target | Channel |
 |------|--------|--------|---------|
-| z_stream | 4.19.27 | 4.19.28 | stable |
-| latest_z | 4.19.0 | 4.19.28 | stable |
-| y_stream | 4.18.41 | 4.19.28 | stable |
+| z_stream | 4.19.28 | 4.19.29 | stable |
+| latest_z | 4.19.0 | 4.19.29 | stable |
+| y_stream | 4.18.41 | 4.19.29 | stable |
 
 ## 4.20 (latest z: 21)
 
@@ -56,7 +56,7 @@ Generated: 2026-07-08 06:08 UTC | Versions: 10 | Paths: 30
 |------|--------|--------|---------|
 | z_stream | 4.20.19 | 4.20.20 | stable |
 | latest_z | 4.20.0 | 4.20.20 | stable |
-| y_stream | 4.19.28 | 4.20.20 | stable |
+| y_stream | 4.19.29 | 4.20.20 | stable |
 | eus | 4.18.41 | 4.20.20 | stable |
 
 ## 4.21 (latest z: 13)
@@ -81,3 +81,9 @@ Generated: 2026-07-08 06:08 UTC | Versions: 10 | Paths: 30
 | Type | Source | Target | Channel |
 |------|--------|--------|---------|
 | y_stream | 4.22.2 | 4.23.0 | candidate |
+
+## 5.0 (latest z: 0)
+
+| Type | Source | Target | Channel |
+|------|--------|--------|---------|
+| y_stream | 4.22.2 | 5.0.0 | candidate |

--- a/docs/release_checklist_upgrade_plan.md
+++ b/docs/release_checklist_upgrade_plan.md
@@ -28,6 +28,9 @@ release_checklist_upgrade_plan -v 4.20.2
 # Major release — generates Y-stream + EUS lanes (4.20 is even)
 release_checklist_upgrade_plan -v 4.20.0
 
+# Cross-major — Y-stream from 4.22
+release_checklist_upgrade_plan -v 5.0.0
+
 # Skip target validation (e.g., target already released to prod)
 release_checklist_upgrade_plan -v 4.16.33 --skip-target-check
 ```

--- a/docs/upgrade_jobs_info.md
+++ b/docs/upgrade_jobs_info.md
@@ -38,6 +38,7 @@ The version format determines the level of resolution:
 | `4.Y.0` | `4.Y`     | Latest-Z                |
 | `4.Y`   | `4.(Y+1)` | Y-stream                |
 | `4.Y`   | `4.(Y+2)` | EUS (both must be even) |
+| `4.Y`   | `5.0`     | Y-stream (cross-major)  |
 
 
 **Validation**: the tool rejects same-version upgrades, downgrades, gaps > 2 minor versions, EUS with odd versions, and EOL sources/targets.
@@ -50,6 +51,7 @@ MINOR format (auto-resolve z-streams):
 upgrade_jobs_info -s 4.20 -t 4.20          # Z-stream
 upgrade_jobs_info -s 4.19 -t 4.20          # Y-stream
 upgrade_jobs_info -s 4.18 -t 4.20          # EUS
+upgrade_jobs_info -s 4.22 -t 5.0           # Cross-major Y-stream
 ```
 
 FULL format (specific versions):

--- a/tests/e2e/upgrade_jobs_info/test_negative.py
+++ b/tests/e2e/upgrade_jobs_info/test_negative.py
@@ -66,7 +66,7 @@ class TestNegativeWithErrorMessages:
         with pytest.raises(ValueError, match="cannot downgrade"):
             get_upgrade_jobs_info(explorer, source_version="5.0", target_version="4.22")
 
-    def test_cross_major_non_existent_target_clean_error(self, explorer):
-        """4.22 -> 5.0 should produce clean error, not KeyError crash."""
-        with pytest.raises(ValueError, match="No released builds found|No stable"):
-            get_upgrade_jobs_info(explorer, source_version="4.22", target_version="5.0")
+    def test_cross_major_upgrade_4_22_to_5_0(self, explorer):
+        """4.22 -> 5.0 is a valid cross-major Y-stream upgrade."""
+        result = get_upgrade_jobs_info(explorer, source_version="4.22", target_version="5.0")
+        assert result["upgrade_type"] == "y_stream"


### PR DESCRIPTION
## Summary
- Fix e2e test that expected 5.0 to have no builds — 5.0 images are now live in Version Explorer, so convert it from a negative test to a positive cross-major Y-stream validation
- Add cross-major upgrade examples (4.22 → 5.0) to CLI reference docs
- Regenerate `current_testing_paths/` snapshot — 5.0.0 now has upgrade path data (Y-stream from 4.22.2) and release checklist entry

## Test plan
- [x] Unit tests: 287/287 pass
- [x] E2E negative tests: 12/12 pass (including the fixed `test_cross_major_upgrade_4_22_to_5_0`)
- [x] Pre-commit: all hooks pass
- [ ] Full e2e suite: 21 pre-existing failures from upstream data quality issues (FBC mismatches, stale `in_stage` flags, 4.12.25 in candidate channel) — none related to this PR