### PR TITLE
Remove 4.17 from upgrade testing since EOL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,8 @@ API responses -> `extract_filtered_build_info()` (from SuccessfulBuild), `extrac
 ## Version Management
 
 ```python
-SUPPORTED_VERSIONS = ["4.12", "4.14", "4.16", "4.17", "4.18", "4.19", "4.20", "4.21", "4.22", "4.23", "5.0"]
-EOL_VERSIONS = frozenset({"4.13", "4.15"})
+SUPPORTED_VERSIONS = ["4.12", "4.14", "4.16", "4.18", "4.19", "4.20", "4.21", "4.22", "4.23", "5.0"]
+EOL_VERSIONS = frozenset({"4.13", "4.15", "4.17"})
 CROSS_MAJOR_Y_STREAM_SOURCES = {"5.0": ["4.22"]}
 _BLOCKED_Y_STREAM_TARGETS = frozenset()
 _NON_EUS_VERSIONS = frozenset({"5.0"})

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ uv sync --extra dev
 
 | Supported | EOL (not tested) |
 |---|---|
-| 4.12, 4.14, 4.16, 4.17, 4.18, 4.19, 4.20, 4.21, 4.22, 4.23, 5.0 | 4.13, 4.15 |
+| 4.12, 4.14, 4.16, 4.18, 4.19, 4.20, 4.21, 4.22, 4.23, 5.0 | 4.13, 4.15, 4.17 |
 
 See [Upgrade Strategy](docs/upgrade-strategy.md) for how versions, upgrade types, and testing strategy work together.
 

--- a/current_testing_paths/release-checklist.json
+++ b/current_testing_paths/release-checklist.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-22 07:59 UTC",
+  "generated_at": "2026-07-27 13:03 UTC",
   "supported_versions": [
     "4.12",
     "4.14",
@@ -17,8 +17,8 @@
       "target_version": "4.12.27",
       "target_build_info": {
         "version": "4.12.27",
-        "bundle_version": "4.12.27-5",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182414",
+        "bundle_version": "4.12.27-11",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1184998",
         "channel": "candidate",
         "in_stage": true,
         "released_to_prod": false
@@ -252,11 +252,11 @@
       }
     },
     "4.22": {
-      "target_version": "4.22.3",
+      "target_version": "4.22.4",
       "target_build_info": {
-        "version": "4.22.3",
-        "bundle_version": "4.22.3.rhel9-26",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178346",
+        "version": "4.22.4",
+        "bundle_version": "4.22.4.rhel9-9",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1183230",
         "channel": "stable",
         "in_stage": true,
         "released_to_prod": false
@@ -296,8 +296,8 @@
       "target_version": "4.23.0",
       "target_build_info": {
         "version": "4.23.0",
-        "bundle_version": "4.23.0.rhel9-24",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1181905",
+        "bundle_version": "4.23.0.rhel9-30",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1184688",
         "channel": "candidate",
         "in_stage": true,
         "released_to_prod": false
@@ -316,8 +316,8 @@
       "target_version": "5.0.0",
       "target_build_info": {
         "version": "5.0.0",
-        "bundle_version": "5.0.0.rhel9-18",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1180810",
+        "bundle_version": "5.0.0.rhel9-28",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1184684",
         "channel": "candidate",
         "in_stage": true,
         "released_to_prod": false

--- a/current_testing_paths/release-checklist.json
+++ b/current_testing_paths/release-checklist.json
@@ -1,10 +1,9 @@
 {
-  "generated_at": "2026-07-21 09:12 UTC",
+  "generated_at": "2026-07-22 07:59 UTC",
   "supported_versions": [
     "4.12",
     "4.14",
     "4.16",
-    "4.17",
     "4.18",
     "4.19",
     "4.20",
@@ -18,8 +17,8 @@
       "target_version": "4.12.27",
       "target_build_info": {
         "version": "4.12.27",
-        "bundle_version": "4.12.27-3",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1181364",
+        "bundle_version": "4.12.27-5",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182414",
         "channel": "candidate",
         "in_stage": true,
         "released_to_prod": false
@@ -76,11 +75,11 @@
       }
     },
     "4.16": {
-      "target_version": "4.16.40",
+      "target_version": "4.16.41",
       "target_build_info": {
-        "version": "4.16.40",
-        "bundle_version": "4.16.40.rhel9-5",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174780",
+        "version": "4.16.41",
+        "bundle_version": "4.16.41.rhel9-16",
+        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182389",
         "channel": "stable",
         "in_stage": true,
         "released_to_prod": false
@@ -109,40 +108,6 @@
         }
       }
     },
-    "4.17": {
-      "target_version": "4.17.54",
-      "target_build_info": {
-        "version": "4.17.54",
-        "bundle_version": "4.17.54.rhel9-4",
-        "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178363",
-        "channel": "stable",
-        "in_stage": true,
-        "released_to_prod": false
-      },
-      "upgrade_lanes": {
-        "Y stream": {
-          "source_version": "4.16.38",
-          "bundle_version": "4.16.38.rhel9-43",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149686",
-          "channel": "stable",
-          "post_upgrade_suite": "UTS-Marker"
-        },
-        "Z stream": {
-          "source_version": "4.17.48",
-          "bundle_version": "4.17.48.rhel9-33",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149392",
-          "channel": "stable",
-          "post_upgrade_suite": "NONE"
-        },
-        "latest z": {
-          "source_version": "4.17.0",
-          "bundle_version": "4.17.0.rhel9-803",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:840694",
-          "channel": "stable",
-          "post_upgrade_suite": "NONE"
-        }
-      }
-    },
     "4.18": {
       "target_version": "4.18.43",
       "target_build_info": {
@@ -154,13 +119,6 @@
         "released_to_prod": false
       },
       "upgrade_lanes": {
-        "Y stream": {
-          "source_version": "4.17.48",
-          "bundle_version": "4.17.48.rhel9-33",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149392",
-          "channel": "stable",
-          "post_upgrade_suite": "UTS-Marker"
-        },
         "Z stream": {
           "source_version": "4.18.36",
           "bundle_version": "4.18.36.rhel9-29",
@@ -173,7 +131,7 @@
           "bundle_version": "4.16.38.rhel9-43",
           "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149686",
           "channel": "stable",
-          "post_upgrade_suite": "NONE"
+          "post_upgrade_suite": "UTS-Marker"
         },
         "latest z": {
           "source_version": "4.18.0",
@@ -237,9 +195,9 @@
           "post_upgrade_suite": "UTS-Marker"
         },
         "Z stream": {
-          "source_version": "4.20.15",
-          "bundle_version": "4.20.15.rhel9-38",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149389",
+          "source_version": "4.20.21",
+          "bundle_version": "4.20.21.rhel9-10",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178347",
           "channel": "stable",
           "post_upgrade_suite": "NONE"
         },
@@ -271,16 +229,16 @@
       },
       "upgrade_lanes": {
         "Y stream": {
-          "source_version": "4.20.15",
-          "bundle_version": "4.20.15.rhel9-38",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149389",
+          "source_version": "4.20.21",
+          "bundle_version": "4.20.21.rhel9-10",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178347",
           "channel": "stable",
           "post_upgrade_suite": "UTS-Marker"
         },
         "Z stream": {
-          "source_version": "4.21.10",
-          "bundle_version": "4.21.10.rhel9-13",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1160141",
+          "source_version": "4.21.13",
+          "bundle_version": "4.21.13.rhel9-7",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178343",
           "channel": "stable",
           "post_upgrade_suite": "NONE"
         },
@@ -305,9 +263,9 @@
       },
       "upgrade_lanes": {
         "Y stream": {
-          "source_version": "4.21.10",
-          "bundle_version": "4.21.10.rhel9-13",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1160141",
+          "source_version": "4.21.13",
+          "bundle_version": "4.21.13.rhel9-7",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178343",
           "channel": "stable",
           "post_upgrade_suite": "UTS-Marker"
         },
@@ -319,9 +277,9 @@
           "post_upgrade_suite": "NONE"
         },
         "EUS": {
-          "source_version": "4.20.15",
-          "bundle_version": "4.20.15.rhel9-38",
-          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149389",
+          "source_version": "4.20.21",
+          "bundle_version": "4.20.21.rhel9-10",
+          "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178347",
           "channel": "stable",
           "post_upgrade_suite": "NONE"
         },

--- a/current_testing_paths/release-checklist.md
+++ b/current_testing_paths/release-checklist.md
@@ -1,10 +1,10 @@
 # Release Checklist
 
-Generated: 2026-07-22 07:59 UTC | Versions: 10
+Generated: 2026-07-27 13:03 UTC | Versions: 10
 
 ## 4.12 (target: 4.12.27)
 
-**Target**: 4.12.27 (4.12.27-5) | channel: candidate | **in stage** | not released to prod
+**Target**: 4.12.27 (4.12.27-11) | channel: candidate | **in stage** | not released to prod
 
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|
@@ -72,9 +72,9 @@ Generated: 2026-07-22 07:59 UTC | Versions: 10
 | Z stream | 4.21.13 | iib:1178343 | stable | NONE |
 | latest z | 4.21.0 | iib:1104286 | stable | NONE |
 
-## 4.22 (target: 4.22.3)
+## 4.22 (target: 4.22.4)
 
-**Target**: 4.22.3 (4.22.3.rhel9-26) | channel: stable | **in stage** | not released to prod
+**Target**: 4.22.4 (4.22.4.rhel9-9) | channel: stable | **in stage** | not released to prod
 
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|
@@ -85,7 +85,7 @@ Generated: 2026-07-22 07:59 UTC | Versions: 10
 
 ## 4.23 (target: 4.23.0)
 
-**Target**: 4.23.0 (4.23.0.rhel9-24) | channel: candidate | **in stage** | not released to prod
+**Target**: 4.23.0 (4.23.0.rhel9-30) | channel: candidate | **in stage** | not released to prod
 
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|
@@ -93,7 +93,7 @@ Generated: 2026-07-22 07:59 UTC | Versions: 10
 
 ## 5.0 (target: 5.0.0)
 
-**Target**: 5.0.0 (5.0.0.rhel9-18) | channel: candidate | **in stage** | not released to prod
+**Target**: 5.0.0 (5.0.0.rhel9-28) | channel: candidate | **in stage** | not released to prod
 
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|

--- a/current_testing_paths/release-checklist.md
+++ b/current_testing_paths/release-checklist.md
@@ -1,10 +1,10 @@
 # Release Checklist
 
-Generated: 2026-07-21 09:12 UTC | Versions: 11
+Generated: 2026-07-22 07:59 UTC | Versions: 10
 
 ## 4.12 (target: 4.12.27)
 
-**Target**: 4.12.27 (4.12.27-3) | channel: candidate | **in stage** | not released to prod
+**Target**: 4.12.27 (4.12.27-5) | channel: candidate | **in stage** | not released to prod
 
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|
@@ -21,9 +21,9 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11
 | EUS | 4.12.24 | iib:1149500 | stable | UTS-Marker |
 | latest z | 4.14.0 | iib:611376 | stable | NONE |
 
-## 4.16 (target: 4.16.40)
+## 4.16 (target: 4.16.41)
 
-**Target**: 4.16.40 (4.16.40.rhel9-5) | channel: stable | **in stage** | not released to prod
+**Target**: 4.16.41 (4.16.41.rhel9-16) | channel: stable | **in stage** | not released to prod
 
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|
@@ -31,25 +31,14 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11
 | EUS | 4.14.24 | iib:1174487 | stable | UTS-Marker |
 | latest z | 4.16.0 | iib:763432 | stable | NONE |
 
-## 4.17 (target: 4.17.54)
-
-**Target**: 4.17.54 (4.17.54.rhel9-4) | channel: stable | **in stage** | not released to prod
-
-| Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
-|------|--------|-----|----------------|-------------------|
-| Y stream | 4.16.38 | iib:1149686 | stable | UTS-Marker |
-| Z stream | 4.17.48 | iib:1149392 | stable | NONE |
-| latest z | 4.17.0 | iib:840694 | stable | NONE |
-
 ## 4.18 (target: 4.18.43)
 
 **Target**: 4.18.43 (4.18.43.rhel9-7) | channel: stable | **in stage** | not released to prod
 
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|
-| Y stream | 4.17.48 | iib:1149392 | stable | UTS-Marker |
 | Z stream | 4.18.36 | iib:1149387 | stable | NONE |
-| EUS | 4.16.38 | iib:1149686 | stable | NONE |
+| EUS | 4.16.38 | iib:1149686 | stable | UTS-Marker |
 | latest z | 4.18.0 | iib:928381 | stable | NONE |
 
 ## 4.19 (target: 4.19.31)
@@ -69,7 +58,7 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|
 | Y stream | 4.19.25 | iib:1149390 | stable | UTS-Marker |
-| Z stream | 4.20.15 | iib:1149389 | stable | NONE |
+| Z stream | 4.20.21 | iib:1178347 | stable | NONE |
 | EUS | 4.18.36 | iib:1149387 | stable | NONE |
 | latest z | 4.20.0 | iib:1063267 | stable | NONE |
 
@@ -79,8 +68,8 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11
 
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|
-| Y stream | 4.20.15 | iib:1149389 | stable | UTS-Marker |
-| Z stream | 4.21.10 | iib:1160141 | stable | NONE |
+| Y stream | 4.20.21 | iib:1178347 | stable | UTS-Marker |
+| Z stream | 4.21.13 | iib:1178343 | stable | NONE |
 | latest z | 4.21.0 | iib:1104286 | stable | NONE |
 
 ## 4.22 (target: 4.22.3)
@@ -89,9 +78,9 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11
 
 | Lane | Source | IIB | Source Channel | Post-Upgrade Suite |
 |------|--------|-----|----------------|-------------------|
-| Y stream | 4.21.10 | iib:1160141 | stable | UTS-Marker |
+| Y stream | 4.21.13 | iib:1178343 | stable | UTS-Marker |
 | Z stream | 4.22.2 | iib:1170572 | stable | NONE |
-| EUS | 4.20.15 | iib:1149389 | stable | NONE |
+| EUS | 4.20.21 | iib:1178347 | stable | NONE |
 | latest z | 4.22.0 | iib:1159577 | stable | NONE |
 
 ## 4.23 (target: 4.23.0)

--- a/current_testing_paths/upgrade-paths.json
+++ b/current_testing_paths/upgrade-paths.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-22 07:59 UTC",
+  "generated_at": "2026-07-27 13:03 UTC",
   "supported_versions": [
     "4.12",
     "4.14",
@@ -20,7 +20,7 @@
     "4.19": 32,
     "4.20": 23,
     "4.21": 15,
-    "4.22": 4,
+    "4.22": 5,
     "4.23": 0,
     "5.0": 0
   },
@@ -39,8 +39,8 @@
           },
           "target": {
             "version": "4.12.27",
-            "bundle_version": "4.12.27-5",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182414",
+            "bundle_version": "4.12.27-11",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1184998",
             "channel": "candidate",
             "in_stage": true,
             "released_to_prod": false
@@ -57,8 +57,8 @@
           },
           "target": {
             "version": "4.12.27",
-            "bundle_version": "4.12.27-5",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182414",
+            "bundle_version": "4.12.27-11",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1184998",
             "channel": "candidate",
             "in_stage": true,
             "released_to_prod": false
@@ -439,7 +439,7 @@
       }
     },
     "4.22": {
-      "latest_z": 4,
+      "latest_z": 5,
       "upgrade_paths": {
         "z_stream": {
           "source": {
@@ -451,9 +451,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.22.3",
-            "bundle_version": "4.22.3.rhel9-26",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178346",
+            "version": "4.22.4",
+            "bundle_version": "4.22.4.rhel9-9",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1183230",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -469,9 +469,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.22.3",
-            "bundle_version": "4.22.3.rhel9-26",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178346",
+            "version": "4.22.4",
+            "bundle_version": "4.22.4.rhel9-9",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1183230",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -487,9 +487,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.22.3",
-            "bundle_version": "4.22.3.rhel9-26",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178346",
+            "version": "4.22.4",
+            "bundle_version": "4.22.4.rhel9-9",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1183230",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -505,9 +505,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.22.3",
-            "bundle_version": "4.22.3.rhel9-26",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178346",
+            "version": "4.22.4",
+            "bundle_version": "4.22.4.rhel9-9",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1183230",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -529,8 +529,8 @@
           },
           "target": {
             "version": "4.23.0",
-            "bundle_version": "4.23.0.rhel9-24",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1181905",
+            "bundle_version": "4.23.0.rhel9-30",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1184688",
             "channel": "candidate",
             "in_stage": true,
             "released_to_prod": false
@@ -552,8 +552,8 @@
           },
           "target": {
             "version": "5.0.0",
-            "bundle_version": "5.0.0.rhel9-18",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1180810",
+            "bundle_version": "5.0.0.rhel9-28",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1184684",
             "channel": "candidate",
             "in_stage": true,
             "released_to_prod": false

--- a/current_testing_paths/upgrade-paths.json
+++ b/current_testing_paths/upgrade-paths.json
@@ -1,10 +1,9 @@
 {
-  "generated_at": "2026-07-21 09:12 UTC",
+  "generated_at": "2026-07-22 07:59 UTC",
   "supported_versions": [
     "4.12",
     "4.14",
     "4.16",
-    "4.17",
     "4.18",
     "4.19",
     "4.20",
@@ -16,8 +15,7 @@
   "latest_z": {
     "4.12": 27,
     "4.14": 27,
-    "4.16": 41,
-    "4.17": 56,
+    "4.16": 42,
     "4.18": 44,
     "4.19": 32,
     "4.20": 23,
@@ -41,8 +39,8 @@
           },
           "target": {
             "version": "4.12.27",
-            "bundle_version": "4.12.27-3",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1181364",
+            "bundle_version": "4.12.27-5",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182414",
             "channel": "candidate",
             "in_stage": true,
             "released_to_prod": false
@@ -59,8 +57,8 @@
           },
           "target": {
             "version": "4.12.27",
-            "bundle_version": "4.12.27-3",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1181364",
+            "bundle_version": "4.12.27-5",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182414",
             "channel": "candidate",
             "in_stage": true,
             "released_to_prod": false
@@ -128,7 +126,7 @@
       }
     },
     "4.16": {
-      "latest_z": 41,
+      "latest_z": 42,
       "upgrade_paths": {
         "z_stream": {
           "source": {
@@ -140,9 +138,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.16.40",
-            "bundle_version": "4.16.40.rhel9-5",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174780",
+            "version": "4.16.41",
+            "bundle_version": "4.16.41.rhel9-16",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182389",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -158,9 +156,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.16.40",
-            "bundle_version": "4.16.40.rhel9-5",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174780",
+            "version": "4.16.41",
+            "bundle_version": "4.16.41.rhel9-16",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182389",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -176,68 +174,9 @@
             "released_to_prod": true
           },
           "target": {
-            "version": "4.16.40",
-            "bundle_version": "4.16.40.rhel9-5",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1174780",
-            "channel": "stable",
-            "in_stage": true,
-            "released_to_prod": false
-          }
-        }
-      }
-    },
-    "4.17": {
-      "latest_z": 56,
-      "upgrade_paths": {
-        "z_stream": {
-          "source": {
-            "version": "4.17.48",
-            "bundle_version": "4.17.48.rhel9-33",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149392",
-            "channel": "stable",
-            "in_stage": true,
-            "released_to_prod": true
-          },
-          "target": {
-            "version": "4.17.56",
-            "bundle_version": "4.17.56.rhel9-1",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1181956",
-            "channel": "candidate",
-            "in_stage": true,
-            "released_to_prod": false
-          }
-        },
-        "latest_z": {
-          "source": {
-            "version": "4.17.0",
-            "bundle_version": "4.17.0.rhel9-803",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:840694",
-            "channel": "stable",
-            "in_stage": false,
-            "released_to_prod": true
-          },
-          "target": {
-            "version": "4.17.56",
-            "bundle_version": "4.17.56.rhel9-1",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1181956",
-            "channel": "candidate",
-            "in_stage": true,
-            "released_to_prod": false
-          }
-        },
-        "y_stream": {
-          "source": {
-            "version": "4.16.38",
-            "bundle_version": "4.16.38.rhel9-43",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149686",
-            "channel": "stable",
-            "in_stage": true,
-            "released_to_prod": true
-          },
-          "target": {
-            "version": "4.17.54",
-            "bundle_version": "4.17.54.rhel9-4",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178363",
+            "version": "4.16.41",
+            "bundle_version": "4.16.41.rhel9-16",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1182389",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": false
@@ -273,24 +212,6 @@
             "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:928381",
             "channel": "stable",
             "in_stage": false,
-            "released_to_prod": true
-          },
-          "target": {
-            "version": "4.18.43",
-            "bundle_version": "4.18.43.rhel9-7",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1181728",
-            "channel": "stable",
-            "in_stage": true,
-            "released_to_prod": false
-          }
-        },
-        "y_stream": {
-          "source": {
-            "version": "4.17.48",
-            "bundle_version": "4.17.48.rhel9-33",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149392",
-            "channel": "stable",
-            "in_stage": true,
             "released_to_prod": true
           },
           "target": {
@@ -386,9 +307,9 @@
       "upgrade_paths": {
         "z_stream": {
           "source": {
-            "version": "4.20.15",
-            "bundle_version": "4.20.15.rhel9-38",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149389",
+            "version": "4.20.21",
+            "bundle_version": "4.20.21.rhel9-10",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178347",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": true
@@ -463,9 +384,9 @@
       "upgrade_paths": {
         "z_stream": {
           "source": {
-            "version": "4.21.10",
-            "bundle_version": "4.21.10.rhel9-13",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1160141",
+            "version": "4.21.13",
+            "bundle_version": "4.21.13.rhel9-7",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178343",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": true
@@ -499,9 +420,9 @@
         },
         "y_stream": {
           "source": {
-            "version": "4.20.15",
-            "bundle_version": "4.20.15.rhel9-38",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149389",
+            "version": "4.20.21",
+            "bundle_version": "4.20.21.rhel9-10",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178347",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": true
@@ -558,9 +479,9 @@
         },
         "y_stream": {
           "source": {
-            "version": "4.21.10",
-            "bundle_version": "4.21.10.rhel9-13",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1160141",
+            "version": "4.21.13",
+            "bundle_version": "4.21.13.rhel9-7",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178343",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": true
@@ -576,9 +497,9 @@
         },
         "eus": {
           "source": {
-            "version": "4.20.15",
-            "bundle_version": "4.20.15.rhel9-38",
-            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1149389",
+            "version": "4.20.21",
+            "bundle_version": "4.20.21.rhel9-10",
+            "iib": "registry-proxy.engineering.redhat.com/rh-osbs/iib:1178347",
             "channel": "stable",
             "in_stage": true,
             "released_to_prod": true

--- a/current_testing_paths/upgrade-paths.md
+++ b/current_testing_paths/upgrade-paths.md
@@ -1,6 +1,6 @@
 # Upgrade Paths
 
-Generated: 2026-07-22 07:59 UTC | Versions: 10 | Paths: 27
+Generated: 2026-07-27 13:03 UTC | Versions: 10 | Paths: 27
 
 ## 4.12 (latest z: 27)
 
@@ -58,14 +58,14 @@ Generated: 2026-07-22 07:59 UTC | Versions: 10 | Paths: 27
 | latest_z | 4.21.0 | stable | 4.21.14 | stable |
 | y_stream | 4.20.21 | stable | 4.21.14 | stable |
 
-## 4.22 (latest z: 4)
+## 4.22 (latest z: 5)
 
 | Type | Source | Source Channel | Target | Target Channel |
 |------|--------|----------------|--------|----------------|
-| z_stream | 4.22.2 | stable | 4.22.3 | stable |
-| latest_z | 4.22.0 | stable | 4.22.3 | stable |
-| y_stream | 4.21.13 | stable | 4.22.3 | stable |
-| eus | 4.20.21 | stable | 4.22.3 | stable |
+| z_stream | 4.22.2 | stable | 4.22.4 | stable |
+| latest_z | 4.22.0 | stable | 4.22.4 | stable |
+| y_stream | 4.21.13 | stable | 4.22.4 | stable |
+| eus | 4.20.21 | stable | 4.22.4 | stable |
 
 ## 4.23 (latest z: 0)
 

--- a/current_testing_paths/upgrade-paths.md
+++ b/current_testing_paths/upgrade-paths.md
@@ -1,6 +1,6 @@
 # Upgrade Paths
 
-Generated: 2026-07-21 09:12 UTC | Versions: 11 | Paths: 31
+Generated: 2026-07-22 07:59 UTC | Versions: 10 | Paths: 27
 
 ## 4.12 (latest z: 27)
 
@@ -17,21 +17,13 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11 | Paths: 31
 | latest_z | 4.14.0 | stable | 4.14.26 | stable |
 | eus | 4.12.24 | stable | 4.14.26 | stable |
 
-## 4.16 (latest z: 41)
+## 4.16 (latest z: 42)
 
 | Type | Source | Source Channel | Target | Target Channel |
 |------|--------|----------------|--------|----------------|
-| z_stream | 4.16.38 | stable | 4.16.40 | stable |
-| latest_z | 4.16.0 | stable | 4.16.40 | stable |
-| eus | 4.14.24 | stable | 4.16.40 | stable |
-
-## 4.17 (latest z: 56)
-
-| Type | Source | Source Channel | Target | Target Channel |
-|------|--------|----------------|--------|----------------|
-| z_stream | 4.17.48 | stable | 4.17.56 | candidate |
-| latest_z | 4.17.0 | stable | 4.17.56 | candidate |
-| y_stream | 4.16.38 | stable | 4.17.54 | stable |
+| z_stream | 4.16.38 | stable | 4.16.41 | stable |
+| latest_z | 4.16.0 | stable | 4.16.41 | stable |
+| eus | 4.14.24 | stable | 4.16.41 | stable |
 
 ## 4.18 (latest z: 44)
 
@@ -39,7 +31,6 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11 | Paths: 31
 |------|--------|----------------|--------|----------------|
 | z_stream | 4.18.36 | stable | 4.18.43 | stable |
 | latest_z | 4.18.0 | stable | 4.18.43 | stable |
-| y_stream | 4.17.48 | stable | 4.18.43 | stable |
 | eus | 4.16.38 | stable | 4.18.43 | stable |
 
 ## 4.19 (latest z: 32)
@@ -54,7 +45,7 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11 | Paths: 31
 
 | Type | Source | Source Channel | Target | Target Channel |
 |------|--------|----------------|--------|----------------|
-| z_stream | 4.20.15 | stable | 4.20.22 | stable |
+| z_stream | 4.20.21 | stable | 4.20.22 | stable |
 | latest_z | 4.20.0 | stable | 4.20.22 | stable |
 | y_stream | 4.19.25 | stable | 4.20.22 | stable |
 | eus | 4.18.36 | stable | 4.20.22 | stable |
@@ -63,9 +54,9 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11 | Paths: 31
 
 | Type | Source | Source Channel | Target | Target Channel |
 |------|--------|----------------|--------|----------------|
-| z_stream | 4.21.10 | stable | 4.21.14 | stable |
+| z_stream | 4.21.13 | stable | 4.21.14 | stable |
 | latest_z | 4.21.0 | stable | 4.21.14 | stable |
-| y_stream | 4.20.15 | stable | 4.21.14 | stable |
+| y_stream | 4.20.21 | stable | 4.21.14 | stable |
 
 ## 4.22 (latest z: 4)
 
@@ -73,8 +64,8 @@ Generated: 2026-07-21 09:12 UTC | Versions: 11 | Paths: 31
 |------|--------|----------------|--------|----------------|
 | z_stream | 4.22.2 | stable | 4.22.3 | stable |
 | latest_z | 4.22.0 | stable | 4.22.3 | stable |
-| y_stream | 4.21.10 | stable | 4.22.3 | stable |
-| eus | 4.20.15 | stable | 4.22.3 | stable |
+| y_stream | 4.21.13 | stable | 4.22.3 | stable |
+| eus | 4.20.21 | stable | 4.22.3 | stable |
 
 ## 4.23 (latest z: 0)
 

--- a/docs/upgrade-strategy.md
+++ b/docs/upgrade-strategy.md
@@ -44,7 +44,7 @@ For upgrade testing:
 
 | Supported                                                          | EOL (not tested) |
 | :----------------------------------------------------------------: | :--------------: |
-| 4.12, 4.14, 4.16, 4.17, 4.18, 4.19, 4.20, 4.21, 4.22, 4.23, 5.0 | 4.13, 4.15       |
+| 4.12, 4.14, 4.16, 4.18, 4.19, 4.20, 4.21, 4.22, 4.23, 5.0 | 4.13, 4.15, 4.17 |
 
 
 **EOL impact:**
@@ -102,8 +102,7 @@ Which upgrade types apply to each supported version (at z >= 2, where all applic
 | 4.12   | --              | yes      | yes      | --  |
 | 4.14   | --              | yes      | yes      | yes |
 | 4.16   | --              | yes      | yes      | yes |
-| 4.17   | yes             | yes      | yes      | --  |
-| 4.18   | yes             | yes      | yes      | yes |
+| 4.18   | --              | yes      | yes      | yes |
 | 4.19   | yes             | yes      | yes      | --  |
 | 4.20   | yes             | yes      | yes      | yes |
 | 4.21   | yes             | yes      | yes      | --  |
@@ -117,6 +116,7 @@ Notes:
 - 4.12: no Y-stream (4.11 not supported), no EUS (4.10 not supported)
 - 4.14: no Y-stream (4.13 is EOL), EUS from 4.12 fills the cross-version gap
 - 4.16: no Y-stream (4.15 is EOL), EUS from 4.14 fills the cross-version gap
+- 4.18: no Y-stream (4.17 is EOL), EUS from 4.16 fills the cross-version gap
 - 4.23: Y-stream from 4.22, developed in parallel with 5.0
 - 5.0: Y-stream from 4.22 (cross-major), not EUS
 - EUS only between even-numbered versions

--- a/src/cnv_upgrade_utilities/upgrade_types.py
+++ b/src/cnv_upgrade_utilities/upgrade_types.py
@@ -16,7 +16,6 @@ SUPPORTED_VERSIONS = [
     "4.12",
     "4.14",
     "4.16",
-    "4.17",
     "4.18",
     "4.19",
     "4.20",
@@ -26,7 +25,7 @@ SUPPORTED_VERSIONS = [
     "5.0",
 ]
 
-EOL_VERSIONS = frozenset({"4.13", "4.15"})
+EOL_VERSIONS = frozenset({"4.13", "4.15", "4.17"})
 
 _SUPPORTED_VERSION_SET = frozenset(SUPPORTED_VERSIONS)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -148,7 +148,7 @@ def negative_paths() -> list[tuple[str, str]]:
         ("4.20", "4.19"),
         ("4.20.5", "4.20.4"),
         ("4.16", "4.19"),
-        ("4.17", "4.19"),
+        ("4.19", "4.21"),
         ("4.20.5", "4.20.5"),
     ]
     eol_paths = _generate_eol_negative_paths()

--- a/tests/e2e/upgrade_jobs_info/test_negative.py
+++ b/tests/e2e/upgrade_jobs_info/test_negative.py
@@ -43,7 +43,7 @@ class TestNegativeWithErrorMessages:
 
     def test_odd_eus_error_message(self, explorer):
         with pytest.raises(ValueError, match="EUS upgrade requires both versions to be even"):
-            get_upgrade_jobs_info(explorer, source_version="4.17", target_version="4.19")
+            get_upgrade_jobs_info(explorer, source_version="4.19", target_version="4.21")
 
     def test_dot_zero_cross_minor_is_y_stream(self, explorer):
         """4.19.0 -> 4.20 is a valid Y-stream (source .0 doesn't force latest-z when minors differ)."""

--- a/tests/test_post_upgrade_suites.py
+++ b/tests/test_post_upgrade_suites.py
@@ -31,10 +31,11 @@ class TestGetPostUpgradeSuite:
     def test_eus_z2_y1_eol_returns_marker(self):
         assert get_post_upgrade_suite(UpgradeType.EUS, 2, minor=14) == POST_UPGRADE_SUITE_MARKER
         assert get_post_upgrade_suite(UpgradeType.EUS, 5, minor=16) == POST_UPGRADE_SUITE_MARKER
+        assert get_post_upgrade_suite(UpgradeType.EUS, 2, minor=18) == POST_UPGRADE_SUITE_MARKER
 
     def test_eus_z2_y1_supported_returns_none(self):
         assert get_post_upgrade_suite(UpgradeType.EUS, 2, minor=20) == POST_UPGRADE_SUITE_NONE
-        assert get_post_upgrade_suite(UpgradeType.EUS, 5, minor=18) == POST_UPGRADE_SUITE_NONE
+        assert get_post_upgrade_suite(UpgradeType.EUS, 5, minor=22) == POST_UPGRADE_SUITE_NONE
 
     def test_eus_z2_without_minor_returns_marker(self):
         assert get_post_upgrade_suite(UpgradeType.EUS, 2) == POST_UPGRADE_SUITE_MARKER

--- a/tests/test_upgrade_types.py
+++ b/tests/test_upgrade_types.py
@@ -141,7 +141,7 @@ class TestDetermineUpgradeType:
         assert determine_upgrade_type("4.16.0", "4.18") == UpgradeType.EUS
 
     def test_dot_zero_source_cross_minor_is_y_stream(self):
-        assert determine_upgrade_type("4.16.0", "4.17") == UpgradeType.Y_STREAM
+        assert determine_upgrade_type("4.18.0", "4.19") == UpgradeType.Y_STREAM
 
     def test_dot_zero_bundle_cross_minor_is_eus(self):
         assert determine_upgrade_type("4.16.0.rhel9-2746", "4.18") == UpgradeType.EUS
@@ -153,8 +153,10 @@ class TestIsEolVersion:
         [
             ("4.13", True),
             ("4.15", True),
+            ("4.17", True),
             ("4.13.5", True),
             ("4.15.10", True),
+            ("4.17.20", True),
             ("4.12", False),
             ("4.16", False),
             ("4.20", False),
@@ -214,8 +216,8 @@ class TestGetApplicableUpgradeTypes:
         assert UpgradeType.Y_STREAM not in result
         assert UpgradeType.EUS in result
 
-    def test_4_17_yes_y_stream_no_eus(self):
-        result = get_applicable_upgrade_types(target_minor=17, target_z=0)
+    def test_4_19_yes_y_stream_no_eus(self):
+        result = get_applicable_upgrade_types(target_minor=19, target_z=0)
         assert UpgradeType.Y_STREAM in result
         assert UpgradeType.EUS not in result
 
@@ -272,16 +274,16 @@ class TestUpgradeTypeAttributes:
 
 class TestVersionConstants:
     def test_supported_versions_match_expected(self):
-        expected = ["4.12", "4.14", "4.16", "4.17", "4.18", "4.19", "4.20", "4.21", "4.22", "4.23", "5.0"]
+        expected = ["4.12", "4.14", "4.16", "4.18", "4.19", "4.20", "4.21", "4.22", "4.23", "5.0"]
         assert SUPPORTED_VERSIONS == expected
 
     def test_eol_versions_match_expected(self):
-        expected = {"4.13", "4.15"}
+        expected = {"4.13", "4.15", "4.17"}
         assert EOL_VERSIONS == expected
 
     def test_no_overlap_supported_and_eol(self):
         assert not set(SUPPORTED_VERSIONS) & EOL_VERSIONS
 
     def test_skip_y_stream_versions_match_expected(self):
-        expected = frozenset({"4.12", "4.14", "4.16"})
+        expected = frozenset({"4.12", "4.14", "4.16", "4.18"})
         assert SKIP_Y_STREAM_VERSIONS == expected


### PR DESCRIPTION
Since 4.17 is EOL, no upgrade testing is required.
1. Deleting related jobs
2. Update docs
3. Update tests.
4. generate jobs metadata - 4.17 not there.